### PR TITLE
重构字幕菜单与偏移交互，新增字幕偏好持久化

### DIFF
--- a/entry/src/main/ets/component/Dialog/SubtitleOffsetDialog.ets
+++ b/entry/src/main/ets/component/Dialog/SubtitleOffsetDialog.ets
@@ -1,6 +1,10 @@
 @CustomDialog
 export struct SubtitleOffsetDialog {
   confirm?: (value: number) => void
+  onOffsetPreview?: (offset: number) => void
+  onCloseButton?: () => void
+  onPrevSubtitle?: (currentOffset: number) => number | undefined
+  onNextSubtitle?: (currentOffset: number) => number | undefined
   controller?: CustomDialogController
   getCurrentValue?: () => number
   title: string = '外挂字幕偏移时间'
@@ -27,10 +31,28 @@ export struct SubtitleOffsetDialog {
   private stepBy(delta: number): void {
     const nextValue = this.getCurrentValueForStep() + delta
     this.inputText = nextValue.toString()
+    this.onOffsetPreview?.(nextValue)
   }
 
   private resetValue(): void {
     this.inputText = '0'
+    this.onOffsetPreview?.(0)
+  }
+
+  private setOffsetValue(nextOffset: number | undefined): void {
+    if (nextOffset === undefined || Number.isNaN(nextOffset)) {
+      return
+    }
+    this.inputText = nextOffset.toString()
+    this.onOffsetPreview?.(nextOffset)
+  }
+
+  private moveToPrevSubtitle(): void {
+    this.setOffsetValue(this.onPrevSubtitle?.(this.getCurrentValueForStep()))
+  }
+
+  private moveToNextSubtitle(): void {
+    this.setOffsetValue(this.onNextSubtitle?.(this.getCurrentValueForStep()))
   }
 
   private getParsedValue(): number {
@@ -79,7 +101,13 @@ export struct SubtitleOffsetDialog {
           .borderRadius(16)
           .width(36)
           .height(36)
-          .onClick(() => this.controller?.close())
+          .onClick(() => {
+            if (this.onCloseButton) {
+              this.onCloseButton()
+              return
+            }
+            this.controller?.close()
+          })
 
           Button({ type: ButtonType.Normal, stateEffect: true }) {
             SymbolGlyph($r('sys.symbol.checkmark'))
@@ -159,6 +187,33 @@ export struct SubtitleOffsetDialog {
           .padding({ left: 2, right: 2 })
           .onClick(() => {
             this.stepBy(1000)
+          })
+      }
+      .width('100%')
+
+      Row({ space: 6 }) {
+        Button('上一条字幕')
+          .fontSize(this.quickBtnFontSize)
+          .fontColor($r('app.color.text_color'))
+          .height(32)
+          .layoutWeight(1)
+          .backgroundColor($r('sys.color.titlebar_icon_background_color'))
+          .borderRadius(12)
+          .padding({ left: 2, right: 2 })
+          .onClick(() => {
+            this.moveToPrevSubtitle()
+          })
+
+        Button('下一条字幕')
+          .fontSize(this.quickBtnFontSize)
+          .fontColor($r('app.color.text_color'))
+          .height(32)
+          .layoutWeight(1)
+          .backgroundColor($r('sys.color.titlebar_icon_background_color'))
+          .borderRadius(12)
+          .padding({ left: 2, right: 2 })
+          .onClick(() => {
+            this.moveToNextSubtitle()
           })
       }
       .width('100%')

--- a/entry/src/main/ets/component/Dialog/SubtitleOffsetDialog.ets
+++ b/entry/src/main/ets/component/Dialog/SubtitleOffsetDialog.ets
@@ -1,0 +1,173 @@
+@CustomDialog
+export struct SubtitleOffsetDialog {
+  confirm?: (value: number) => void
+  controller?: CustomDialogController
+  getCurrentValue?: () => number
+  title: string = '外挂字幕偏移时间'
+  @State inputText: string = ''
+  inputController: TextInputController = new TextInputController()
+  minOffset: number = -50000
+  maxOffset: number = 50000
+  inputId: string = 'subtitle_offset_input'
+  quickBtnFontSize: number = 14
+
+  aboutToAppear(): void {
+    const currentOffset = this.getCurrentValue ? this.getCurrentValue() : 0
+    this.inputText = currentOffset.toString()
+  }
+
+  private getCurrentValueForStep(): number {
+    const currentInput = this.getParsedValue()
+    if (!Number.isNaN(currentInput)) {
+      return currentInput
+    }
+    return this.getCurrentValue ? this.getCurrentValue() : 0
+  }
+
+  private stepBy(delta: number): void {
+    const nextValue = this.getCurrentValueForStep() + delta
+    this.inputText = nextValue.toString()
+  }
+
+  private resetValue(): void {
+    this.inputText = '0'
+  }
+
+  private getParsedValue(): number {
+    const value = this.inputText.trim()
+    if (value.length === 0 || value === '-' || value === '+') {
+      return Number.NaN
+    }
+    return parseInt(value, 10)
+  }
+
+  build() {
+    Column({ space: 8 }) {
+      Text(this.title)
+        .fontSize(20)
+        .fontColor($r('app.color.text_color'))
+        .fontWeight(FontWeight.Bold)
+        .margin({ top: 0, bottom: 5 })
+
+      Row() {
+        TextInput({
+          text: this.inputText,
+          placeholder: `${this.getCurrentValue ? this.getCurrentValue() : 0}`,
+          controller: this.inputController
+        })
+          .keyboardAppearance(KeyboardAppearance.IMMERSIVE)
+          .clickEffect({ level: ClickEffectLevel.LIGHT, scale: 0.9 })
+          .onChange((input: string) => this.inputText = input.trim())
+          .inputFilter('^[-+]?\\d*$')
+          .type(InputType.NUMBER_DECIMAL)
+          .enableAutoFill(true)
+          .id(this.inputId)
+          .height(36)
+          .layoutWeight(1)
+          .maxLength(10)
+          .maxLines(1)
+          .enterKeyType(EnterKeyType.Done)
+
+        Row({ space: 6 }) {
+          Button({ type: ButtonType.Normal, stateEffect: true }) {
+            SymbolGlyph($r('sys.symbol.xmark'))
+              .fontSize(16)
+              .fontColor([$r('app.color.text_color')])
+          }
+          .clickEffect({ level: ClickEffectLevel.LIGHT, scale: 0.9 })
+          .backgroundColor($r('sys.color.titlebar_icon_background_color'))
+          .borderRadius(16)
+          .width(36)
+          .height(36)
+          .onClick(() => this.controller?.close())
+
+          Button({ type: ButtonType.Normal, stateEffect: true }) {
+            SymbolGlyph($r('sys.symbol.checkmark'))
+              .fontSize(16)
+              .fontColor([$r('app.color.text_color')])
+          }
+          .clickEffect({ level: ClickEffectLevel.LIGHT, scale: 0.9 })
+          .backgroundColor($r('sys.color.titlebar_icon_background_color'))
+          .borderRadius(16)
+          .width(36)
+          .height(36)
+          .onClick(() => {
+            this.confirm?.(this.getParsedValue())
+          })
+        }
+        .margin({ left: 8 })
+      }
+      .width('100%')
+      .alignItems(VerticalAlign.Center)
+
+      Row({ space: 4 }) {
+        Button('-1000')
+          .fontSize(this.quickBtnFontSize)
+          .fontColor($r('app.color.text_color'))
+          .height(32)
+          .layoutWeight(1)
+          .backgroundColor($r('sys.color.titlebar_icon_background_color'))
+          .borderRadius(12)
+          .padding({ left: 2, right: 2 })
+          .onClick(() => {
+            this.stepBy(-1000)
+          })
+
+        Button('-100')
+          .fontSize(this.quickBtnFontSize)
+          .fontColor($r('app.color.text_color'))
+          .height(32)
+          .layoutWeight(1)
+          .backgroundColor($r('sys.color.titlebar_icon_background_color'))
+          .borderRadius(12)
+          .padding({ left: 2, right: 2 })
+          .onClick(() => {
+            this.stepBy(-100)
+          })
+
+        Button('重置')
+          .fontSize(this.quickBtnFontSize)
+          .fontColor($r('app.color.text_color'))
+          .height(32)
+          .layoutWeight(1)
+          .backgroundColor($r('sys.color.titlebar_icon_background_color'))
+          .borderRadius(12)
+          .padding({ left: 2, right: 2 })
+          .onClick(() => {
+            this.resetValue()
+          })
+
+        Button('+100')
+          .fontSize(this.quickBtnFontSize)
+          .fontColor($r('app.color.text_color'))
+          .height(32)
+          .layoutWeight(1)
+          .backgroundColor($r('sys.color.titlebar_icon_background_color'))
+          .borderRadius(12)
+          .padding({ left: 2, right: 2 })
+          .onClick(() => {
+            this.stepBy(100)
+          })
+
+        Button('+1000')
+          .fontSize(this.quickBtnFontSize)
+          .fontColor($r('app.color.text_color'))
+          .height(32)
+          .layoutWeight(1)
+          .backgroundColor($r('sys.color.titlebar_icon_background_color'))
+          .borderRadius(12)
+          .padding({ left: 2, right: 2 })
+          .onClick(() => {
+            this.stepBy(1000)
+          })
+      }
+      .width('100%')
+    }
+    .padding({
+      top: 10,
+      bottom: 10,
+      left: 15,
+      right: 15
+    })
+  }
+}

--- a/entry/src/main/ets/component/Dialog/SubtitleOffsetDialog.ets
+++ b/entry/src/main/ets/component/Dialog/SubtitleOffsetDialog.ets
@@ -72,23 +72,32 @@ export struct SubtitleOffsetDialog {
         .margin({ top: 0, bottom: 5 })
 
       Row() {
-        TextInput({
-          text: this.inputText,
-          placeholder: `${this.getCurrentValue ? this.getCurrentValue() : 0}`,
-          controller: this.inputController
-        })
-          .keyboardAppearance(KeyboardAppearance.IMMERSIVE)
-          .clickEffect({ level: ClickEffectLevel.LIGHT, scale: 0.9 })
-          .onChange((input: string) => this.inputText = input.trim())
-          .inputFilter('^[-+]?\\d*$')
-          .type(InputType.NUMBER_DECIMAL)
-          .enableAutoFill(true)
-          .id(this.inputId)
-          .height(36)
-          .layoutWeight(1)
-          .maxLength(10)
-          .maxLines(1)
-          .enterKeyType(EnterKeyType.Done)
+        Stack({ alignContent: Alignment.End }) {
+          TextInput({
+            text: this.inputText,
+            placeholder: `${this.getCurrentValue ? this.getCurrentValue() : 0}`,
+            controller: this.inputController
+          })
+            .keyboardAppearance(KeyboardAppearance.IMMERSIVE)
+            .clickEffect({ level: ClickEffectLevel.LIGHT, scale: 0.9 })
+            .onChange((input: string) => this.inputText = input.trim())
+            .inputFilter('^[-+]?\\d*$')
+            .type(InputType.NUMBER_DECIMAL)
+            .enableAutoFill(true)
+            .id(this.inputId)
+            .height(36)
+            .maxLength(10)
+            .maxLines(1)
+            .enterKeyType(EnterKeyType.Done)
+            .padding({ right: 26 })
+
+          Text('ms')
+            .fontSize(13)
+            .fontColor('#909399')
+            .margin({ right: 10 })
+        }
+        .height(36)
+        .layoutWeight(1)
 
         Row({ space: 6 }) {
           Button({ type: ButtonType.Normal, stateEffect: true }) {

--- a/entry/src/main/ets/component/PlayerComponent/SubtitlePanelComponent.ets
+++ b/entry/src/main/ets/component/PlayerComponent/SubtitlePanelComponent.ets
@@ -118,7 +118,7 @@ export struct SubtitlePanelComponent {
 
       if (canIUse('SystemCapability.AI.AICaption')) {
         MenuItem({
-          content: 'AI 字幕：' + (this.isAIAsrShown ? '显示' : '隐藏')
+          content: 'AI 字幕'
         })
           .contentFontColor(this.isAIAsrShown ? $r('sys.color.white') :
             $r('app.color.text_color'))

--- a/entry/src/main/ets/component/PlayerComponent/SubtitlePanelComponent.ets
+++ b/entry/src/main/ets/component/PlayerComponent/SubtitlePanelComponent.ets
@@ -224,13 +224,8 @@ export struct SubtitlePanelComponent {
             $r('app.color.text_color'))
           .backgroundColor(this.player.subtitleTrackSelected === item.id ? $r('app.color.main_color') : '')
           .onClick(() => {
+            this.player.selectSubtitleTrack(item.id)
             this.onInnerSubtitleClick()
-            if (this.player instanceof MpvController) {
-              this.player?.selectSubtitleTrack(item.id)
-            }
-            if (this.player instanceof AVPlayerController) {
-              this.player?.selectSubtitleTrack(item.id)
-            }
           })
       }, (item: MpvSubtitleTrack | SubtitleTrack) => `${item.id}`)
     }

--- a/entry/src/main/ets/component/PlayerComponent/SubtitlePanelComponent.ets
+++ b/entry/src/main/ets/component/PlayerComponent/SubtitlePanelComponent.ets
@@ -22,8 +22,6 @@ export struct SubtitlePanelComponent {
   }
   onExternalSubtitleClick = () => {
   }
-  onExternalSubtitleOffClick = () => {
-  }
   onAIAsrClick = () => {
   }
 
@@ -99,6 +97,9 @@ export struct SubtitlePanelComponent {
         })
           .contentFontColor(this.isExternalSubtitleActive() ? $r('sys.color.white') :
             $r('app.color.text_color'))
+          .onClick(() => {
+            this.onExternalSubtitleClick()
+          })
           .height(40)
           .backgroundColor(this.isExternalSubtitleActive() ? $r('app.color.main_color') : '')
           .borderRadius(16)
@@ -148,18 +149,6 @@ export struct SubtitlePanelComponent {
   @Builder
   ExternalSubtitleSubmenu() {
     Menu() {
-      MenuItem({
-        content: this.isExternalSubtitleActive() ? "关闭外挂字幕" : "启用外挂字幕"
-      })
-        .menuItemExtend()
-        .onClick(() => {
-          if (this.isExternalSubtitleActive()) {
-            this.onExternalSubtitleOffClick()
-            return
-          }
-          this.onExternalSubtitleClick()
-        })
-
       MenuItem({
         content: "字幕偏移"
       })

--- a/entry/src/main/ets/component/PlayerComponent/SubtitlePanelComponent.ets
+++ b/entry/src/main/ets/component/PlayerComponent/SubtitlePanelComponent.ets
@@ -5,56 +5,116 @@ import { MpvSubtitleTrack } from '../../controller/MpvController/MpvTypes'
 import { SubtitleTrack } from '../../interfaces/AudioTrackInterface'
 import { InnerSubtitleDataSource } from '../../utils/DataUtil'
 import VideoOperateUtil from '../../utils/VideoOperateUtil'
+import ToolsUtil from '../../utils/ToolsUtil'
 
 @Component
 export struct SubtitlePanelComponent {
   @Link subtitleVisibility: Visibility
   @Link isAIAsrShown: boolean
   @Link subtitle3DMode: Subtitle3DMode
-  @State threeDSubtitleValue: string[] = ["不使用", "左/右", "上/下"]
   @State innerSubtitleMenu: InnerSubtitleDataSource = new InnerSubtitleDataSource([])
   @Consume('player') player: AVPlayerController | MpvController
+  onSubtitleOffClick = () => {
+  }
   onSubtitleOffsetTime = () => {
   }
   onInnerSubtitleClick = () => {
   }
   onExternalSubtitleClick = () => {
   }
+  onExternalSubtitleOffClick = () => {
+  }
   onAIAsrClick = () => {
   }
 
   aboutToAppear(): void {
-    if (this.player.subtitleTrack.length > 0) {
-      this.innerSubtitleMenu = new InnerSubtitleDataSource(this.player.subtitleTrack)
-    }
+    this.innerSubtitleMenu = new InnerSubtitleDataSource(this.player.subtitleTrack)
+  }
+
+  private hasExternalSubtitle(): boolean {
+    return (this.player.nowPlaying?.external_subtitle_format?.length ?? 0) > 0
+  }
+
+  private isExternalSubtitleActive(): boolean {
+    return this.subtitleVisibility === Visibility.Visible &&
+      this.player.subtitleSelected === SubtitleMode.EXTERNAL_SUBTITLE
+  }
+
+  private isSubtitleOffActive(): boolean {
+    return this.subtitleVisibility === Visibility.None && !this.isAIAsrShown
+  }
+
+  private isInnerSubtitleActive(): boolean {
+    return this.subtitleVisibility === Visibility.Visible &&
+      this.player.subtitleSelected === SubtitleMode.INNER_SUBTITLE
   }
 
   build() {
     Menu() {
       MenuItem({
-        content: '内嵌字幕：' + (this.subtitleVisibility === Visibility.Visible ? '显示' : '字幕隐藏'),
-        builder: this.InnerSubtitleMenu,
+        content: '关闭字幕'
       })
-        .contentFontColor(this.player.subtitleSelected === SubtitleMode.INNER_SUBTITLE ? $r('sys.color.white') :
-          $r('app.color.text_color'))
-        .height(40)
-        .backgroundColor(this.player.subtitleSelected === SubtitleMode.INNER_SUBTITLE ? $r('app.color.main_color') : '')
-        .borderRadius(16)
-        .width('100%')
-
-      MenuItem({
-        content: '外挂字幕：' + (this.subtitleVisibility === Visibility.Visible ? '显示' : '字幕隐藏')
-      })
-        .contentFontColor(this.player.subtitleSelected === SubtitleMode.EXTERNAL_SUBTITLE ? $r('sys.color.white') :
+        .contentFontColor(this.isSubtitleOffActive() ? $r('sys.color.white') :
           $r('app.color.text_color'))
         .onClick(() => {
-          this.onExternalSubtitleClick()
+          this.onSubtitleOffClick()
         })
         .height(40)
-        .backgroundColor(this.player.subtitleSelected === SubtitleMode.EXTERNAL_SUBTITLE ? $r('app.color.main_color') :
+        .backgroundColor(this.isSubtitleOffActive() ? $r('app.color.main_color') :
           '')
         .borderRadius(16)
         .width('100%')
+
+      if (this.player.subtitleTrack.length > 0) {
+        MenuItem({
+          content: '内嵌字幕',
+          builder: this.InnerSubtitleMenu,
+        })
+          .contentFontColor(this.isInnerSubtitleActive() ? $r('sys.color.white') :
+            $r('app.color.text_color'))
+          .onClick(() => {
+            this.onInnerSubtitleClick()
+          })
+          .height(40)
+          .backgroundColor(this.isInnerSubtitleActive() ? $r('app.color.main_color') : '')
+          .borderRadius(16)
+          .width('100%')
+      } else {
+        MenuItem({
+          content: '无内嵌字幕'
+        })
+          .contentFontColor($r('app.color.text_color'))
+          .onClick(() => {
+            ToolsUtil.showToast('当前视频没有内嵌字幕')
+          })
+          .height(40)
+          .borderRadius(16)
+          .width('100%')
+      }
+
+      if (this.hasExternalSubtitle()) {
+        MenuItem({
+          content: '外挂字幕',
+          builder: this.ExternalSubtitleSubmenu
+        })
+          .contentFontColor(this.isExternalSubtitleActive() ? $r('sys.color.white') :
+            $r('app.color.text_color'))
+          .height(40)
+          .backgroundColor(this.isExternalSubtitleActive() ? $r('app.color.main_color') : '')
+          .borderRadius(16)
+          .width('100%')
+      } else {
+        MenuItem({
+          content: '无外挂字幕'
+        })
+          .contentFontColor($r('app.color.text_color'))
+          .onClick(() => {
+            ToolsUtil.showToast('当前视频没有外挂字幕')
+          })
+          .height(40)
+          .borderRadius(16)
+          .width('100%')
+      }
 
       if (canIUse('SystemCapability.AI.AICaption')) {
         MenuItem({
@@ -72,23 +132,44 @@ export struct SubtitlePanelComponent {
       }
 
       MenuItem({
-        content: "字幕偏移",
-      })
-        .contentFontColor($r('app.color.text_color'))
-        .onClick(() => {
-          this.onSubtitleOffsetTime()
-        })
-
-      MenuItem({
         content: "3D 字幕",
         builder: this.ThreeDSubtitleSubmenu,
       })
-        .contentFontColor($r('app.color.text_color'))
+        .contentFontColor(this.subtitle3DMode !== Subtitle3DMode.DISABLED ? $r('sys.color.white') :
+          $r('app.color.text_color'))
+        .backgroundColor(this.subtitle3DMode !== Subtitle3DMode.DISABLED ? $r('app.color.main_color') : '')
         .menuItemExtend()
     }
     .width(240)
     .height('auto')
     .subMenuExpandingMode(SubMenuExpandingMode.STACK_EXPAND)
+  }
+
+  @Builder
+  ExternalSubtitleSubmenu() {
+    Menu() {
+      MenuItem({
+        content: this.isExternalSubtitleActive() ? "关闭外挂字幕" : "启用外挂字幕"
+      })
+        .menuItemExtend()
+        .onClick(() => {
+          if (this.isExternalSubtitleActive()) {
+            this.onExternalSubtitleOffClick()
+            return
+          }
+          this.onExternalSubtitleClick()
+        })
+
+      MenuItem({
+        content: "字幕偏移"
+      })
+        .menuItemExtend()
+        .onClick(() => {
+          this.onSubtitleOffsetTime()
+        })
+    }
+    .width(140)
+    .height('auto')
   }
 
   @Builder
@@ -138,7 +219,12 @@ export struct SubtitlePanelComponent {
           content: item.id + " " + VideoOperateUtil.getLanguageName(item.title) + " " +
             VideoOperateUtil.getLanguageName(item.lang)
         })
+          .menuItemExtend()
+          .contentFontColor(this.player.subtitleTrackSelected === item.id ? $r('sys.color.white') :
+            $r('app.color.text_color'))
+          .backgroundColor(this.player.subtitleTrackSelected === item.id ? $r('app.color.main_color') : '')
           .onClick(() => {
+            this.onInnerSubtitleClick()
             if (this.player instanceof MpvController) {
               this.player?.selectSubtitleTrack(item.id)
             }
@@ -146,7 +232,7 @@ export struct SubtitlePanelComponent {
               this.player?.selectSubtitleTrack(item.id)
             }
           })
-      }, (item: MpvSubtitleTrack | SubtitleTrack) => item.title)
+      }, (item: MpvSubtitleTrack | SubtitleTrack) => `${item.id}`)
     }
   }
 }

--- a/entry/src/main/ets/component/PlayerComponent/XComponents.ets
+++ b/entry/src/main/ets/component/PlayerComponent/XComponents.ets
@@ -11,6 +11,7 @@ export struct XComponents {
   @Consume('player') player: AVPlayerController | MpvController
   @Prop choosePlayer: string
   @Prop subtitle: string
+  @Prop hideSubtitle: boolean = false
   @Link showControl: boolean
   @Link subtitleVisibility: Visibility
   @Link subtitle3DMode: Subtitle3DMode
@@ -58,7 +59,7 @@ export struct XComponents {
         screenWidth: this.player.screenWidth,
         screenHeight: this.player.screenHeight,
         showControl: this.showControl,
-        subTitleVisibility: this.subtitleVisibility,
+        subTitleVisibility: this.hideSubtitle ? Visibility.None : this.subtitleVisibility,
         subtitle3DMode: this.subtitle3DMode
       })
     }

--- a/entry/src/main/ets/component/VideoItemComponent/VideoItemComponent.ets
+++ b/entry/src/main/ets/component/VideoItemComponent/VideoItemComponent.ets
@@ -439,6 +439,7 @@ export struct VideoList {
         symbolStartIcon: new SymbolGlyphModifier($r('sys.symbol.textformat_size_square')), content: '导入或删除字幕'
       })
         .onClick(async () => {
+          DataSyncUtil.editingVideo = item!
           await SubtitleUtil.importOrDeleteSubtitleProcess(item!)
           const targetIndex = SelectFileUtil.getItemIndex(this.videoListController.videoMetaDataList, item!)
           if (targetIndex !== -1) {

--- a/entry/src/main/ets/controller/AVPlayerController.ets
+++ b/entry/src/main/ets/controller/AVPlayerController.ets
@@ -35,6 +35,7 @@ export class AVPlayerController implements PlayerControllerInterface {
   @Track playTime: number = 0
   @Track audioTrack: AudioTrack[] = []
   @Track subtitleTrack: SubtitleTrack[] = []
+  @Track subtitleTrackSelected: number = -1
   @Track volume: number = 0
   @Track volumeActually: number = 0
   @Track screenBrightness: number = 0
@@ -200,9 +201,11 @@ export class AVPlayerController implements PlayerControllerInterface {
 
   async getSubtitleTrackList() {
     this.subtitleTrack = await VideoOperateUtil.getInnerSubtitles(this.avPlayer!)
+    this.subtitleTrackSelected = this.subtitleTrack.length > 0 ? this.subtitleTrack[0].id : -1
   }
 
   selectSubtitleTrack(index: number): void {
+    this.subtitleTrackSelected = index
     this.avPlayer?.selectTrack(index)?.catch(() => {
       ToolsUtil.addLogger('selectTrack error', true)
     })

--- a/entry/src/main/ets/controller/MpvController/MpvController.ets
+++ b/entry/src/main/ets/controller/MpvController/MpvController.ets
@@ -6,6 +6,7 @@ import {
   getCurrentPosition as mpvGetCurrentPosition,
   getDuration as mpvGetDuration,
   getSubtitleTracks as mpvGetSubtitleTracks,
+  getCurrentSubtitleTrack as mpvGetCurrentSubtitleTrack,
   getVideoHeight as mpvGetVideoHeight,
   getVideoWidth as mpvGetVideoWidth,
   loadVideo as mpvLoadVideo,
@@ -341,7 +342,14 @@ export class MpvController implements PlayerControllerInterface {
 
   getSubtitleTrackList() {
     this.subtitleTrack = mpvGetSubtitleTracks(this.mpvHandle) as MpvSubtitleTrack[]
-    this.subtitleTrackSelected = this.subtitleTrack.length > 0 ? this.subtitleTrack[0].id : -1
+    if (this.subtitleTrack.length === 0) {
+      this.subtitleTrackSelected = -1
+      return
+    }
+
+    const currentTrackId = mpvGetCurrentSubtitleTrack(this.mpvHandle)
+    const hasCurrentTrack = this.subtitleTrack.some((track) => track.id === currentTrackId)
+    this.subtitleTrackSelected = hasCurrentTrack ? currentTrackId : this.subtitleTrack[0].id
   }
 
   selectSubtitleTrack(trackId: number): void {

--- a/entry/src/main/ets/controller/MpvController/MpvController.ets
+++ b/entry/src/main/ets/controller/MpvController/MpvController.ets
@@ -59,6 +59,7 @@ export class MpvController implements PlayerControllerInterface {
   @Track volumeActually: number = 0
   @Track audioTrack: MpvAudioTrack[] = []
   @Track subtitleTrack: MpvSubtitleTrack[] = []
+  @Track subtitleTrackSelected: number = -1
   @Track screenBrightness: number = 0
   @Track onSwipingVoice: boolean = false
   @Track subtitleSelected: SubtitleMode = SubtitleMode.INNER_SUBTITLE
@@ -340,9 +341,11 @@ export class MpvController implements PlayerControllerInterface {
 
   getSubtitleTrackList() {
     this.subtitleTrack = mpvGetSubtitleTracks(this.mpvHandle) as MpvSubtitleTrack[]
+    this.subtitleTrackSelected = this.subtitleTrack.length > 0 ? this.subtitleTrack[0].id : -1
   }
 
   selectSubtitleTrack(trackId: number): void {
+    this.subtitleTrackSelected = trackId
     mpvSelectSubtitle(this.mpvHandle, trackId)
   }
 

--- a/entry/src/main/ets/interfaces/VideoMetadataInterface.ets
+++ b/entry/src/main/ets/interfaces/VideoMetadataInterface.ets
@@ -14,6 +14,12 @@ export interface VideoMetadata {
   external_subtitle_format: string
   pointA: number
   pointB: number
+  subtitle_mode?: number
+  subtitle_visible?: boolean
+  subtitle_ai_asr_shown?: boolean
+  subtitle_3d_mode?: number
+  subtitle_offset_millis?: number
+  subtitle_track_id?: number
 }
 
 // 保存数据
@@ -25,4 +31,10 @@ export interface SaveOptions {
   totalTime?: number
   pointA?: number
   pointB?: number
+  subtitleMode?: number
+  subtitleVisible?: boolean
+  subtitleAIAsrShown?: boolean
+  subtitle3DMode?: number
+  subtitleOffsetMillis?: number
+  subtitleTrackId?: number
 }

--- a/entry/src/main/ets/pages/VideoPlayer/Player.ets
+++ b/entry/src/main/ets/pages/VideoPlayer/Player.ets
@@ -32,6 +32,7 @@ import { FastForwardPanelBuilder } from '../../component/PlayerComponent/FastFor
 import { VolumeSwipingPanelBuilder } from '../../component/PlayerComponent/VolumeSwipingPanelBuilder'
 import { SwipingPlayTimePanelBuilder } from '../../component/PlayerComponent/SwipingPlayTimePanelBuilder'
 import { SubtitlePanelComponent } from '../../component/PlayerComponent/SubtitlePanelComponent'
+import { SubtitleDisplayBuilder } from '../../component/PlayerComponent/SubtitleDisplayBuilder'
 import { Privacy, Setting } from '../../utils/ObservedUtil'
 import { PlayerControllerFactory } from '../../controller/PlayerControllerFactory'
 import { XComponents } from '../../component/PlayerComponent/XComponents'
@@ -88,21 +89,119 @@ export struct Player { // 播放页
   @State subtitle3DMode: Subtitle3DMode = Subtitle3DMode.DISABLED
   @Consume('pathStack') pathStack: NavPathStack
   @State exitVideoTime: number = 0
+  @State isAdjustingSubtitleOffset: boolean = false
+  private subtitleOffsetPreviewBase: number = 0
+  private subtitleOffsetShouldResumePlayback: boolean = false
+
+  private isOffsetSubtitleOverlayActive(): boolean {
+    return this.isAdjustingSubtitleOffset && this.player.subtitleSelected === SubtitleMode.EXTERNAL_SUBTITLE
+  }
+
+  private refreshExternalSubtitlePreview(offset: number): void {
+    if (this.player.subtitleSelected !== SubtitleMode.EXTERNAL_SUBTITLE) {
+      return
+    }
+    this.player.subtitle = SubtitleUtil.getSubtitlesAtTime(this.player.playTime, offset)
+  }
+
+  private refreshExternalSubtitleByPlaybackTime(): void {
+    if (this.isAdjustingSubtitleOffset) {
+      return
+    }
+    if (this.player.subtitleSelected !== SubtitleMode.EXTERNAL_SUBTITLE) {
+      return
+    }
+    if (this.subtitleVisibility !== Visibility.Visible) {
+      return
+    }
+    this.player.subtitle = SubtitleUtil.getSubtitlesAtTime(this.player.playTime)
+  }
+
+  private resumePlaybackAfterSubtitleOffsetIfNeeded(): void {
+    if (!this.subtitleOffsetShouldResumePlayback) {
+      return
+    }
+    this.subtitleOffsetShouldResumePlayback = false
+    if (!this.player.playing) {
+      this.player.play()
+    }
+  }
+
+  private finishSubtitleOffsetSession(): void {
+    this.isAdjustingSubtitleOffset = false
+    this.resumePlaybackAfterSubtitleOffsetIfNeeded()
+  }
+
+  private cancelSubtitleOffsetSession(): void {
+    if (!this.isAdjustingSubtitleOffset) {
+      return
+    }
+    this.refreshExternalSubtitlePreview(this.subtitleOffsetPreviewBase)
+    this.finishSubtitleOffsetSession()
+  }
+
+  private getAdjacentSubtitleOffset(direction: 'prev' | 'next', currentOffset: number): number | undefined {
+    const targetOffset = SubtitleUtil.getAdjacentSubtitleOffset(this.player.playTime, currentOffset, direction)
+    if (targetOffset === undefined) {
+      ToolsUtil.showToast(direction === 'prev' ? '没有上一条字幕' : '没有下一条字幕')
+      return undefined
+    }
+    if (Math.abs(targetOffset) > 50000) {
+      ToolsUtil.showToast('目标字幕超出偏移范围：-50000 到 50000')
+      return undefined
+    }
+    return Math.round(targetOffset)
+  }
+
+  private activateExternalSubtitle(): void {
+    this.isAIAsrShown = false
+    this.subtitleVisibility = Visibility.Visible
+    this.player.subtitleSelected = SubtitleMode.EXTERNAL_SUBTITLE
+    this.refreshExternalSubtitleByPlaybackTime()
+  }
+
+  private turnOffSubtitleDisplay(): void {
+    this.isAIAsrShown = false
+    this.subtitleVisibility = Visibility.None
+  }
+
   subtitleTimestampInputDialog: CustomDialogController = new CustomDialogController({
     builder: SubtitleOffsetDialog({
       getCurrentValue: () => SubtitleUtil.offsetMillis,
+      onOffsetPreview: (offset: number) => {
+        this.refreshExternalSubtitlePreview(offset)
+      },
+      onCloseButton: () => {
+        this.cancelSubtitleOffsetSession()
+        this.subtitleTimestampInputDialog.close()
+      },
+      onPrevSubtitle: (currentOffset: number) => {
+        return this.getAdjacentSubtitleOffset('prev', currentOffset)
+      },
+      onNextSubtitle: (currentOffset: number) => {
+        return this.getAdjacentSubtitleOffset('next', currentOffset)
+      },
       confirm: (input: number) => {
         if (Number.isNaN(input)) {
           ToolsUtil.showToast('未输入偏移')
+          this.cancelSubtitleOffsetSession()
           this.subtitleTimestampInputDialog.close()
         } else if (Math.abs(input) <= 50000) {
           SubtitleUtil.offsetMillis = input
+          this.refreshExternalSubtitlePreview(input)
+          this.finishSubtitleOffsetSession()
           this.subtitleTimestampInputDialog.close()
         } else {
           ToolsUtil.showToast('输入错误：请输入 -50000 到 50000 的整数')
         }
       },
-    }), cornerRadius: 20, shadow: DefaultDialogShadow
+    }),
+    cornerRadius: 20,
+    shadow: DefaultDialogShadow,
+    maskColor: '#00000000',
+    cancel: () => {
+      this.cancelSubtitleOffsetSession()
+    }
   })
 
   async aboutToAppear(): Promise<void> {
@@ -191,6 +290,7 @@ export struct Player { // 播放页
       ToolsUtil.addLogger("播放器跳转完成", false, this.pathStack)
       this.player.playTime = percent
       AVSessionUtil.updatePlaybackSessionState(this.player.playing, this.player.playTime, this.player.repeatMode)
+      this.refreshExternalSubtitleByPlaybackTime()
       if (!this.player.playing) {
         this.player.startImageAnalyzer(this.xComponentController)
       }
@@ -233,6 +333,8 @@ export struct Player { // 播放页
           this.player.lockVisibility = false
           this.player.isSliderPlayTimeChange = false
           this.player.onSwiping = false
+          this.isAdjustingSubtitleOffset = false
+          this.refreshExternalSubtitleByPlaybackTime()
           ToolsUtil.addLogger("界面控制状态重置完成", false, this.pathStack)
           break
         case 'completed':
@@ -332,6 +434,7 @@ export struct Player { // 播放页
             xComponentController: this.xComponentController,
             subtitle: this.player.subtitle,
             choosePlayer: NavigationAddress.AV_PLAYER,
+            hideSubtitle: this.isOffsetSubtitleOverlayActive(),
             showControl: this.showControl,
             subtitleVisibility: this.subtitleVisibility,
             subtitle3DMode: this.subtitle3DMode,
@@ -548,6 +651,26 @@ export struct Player { // 播放页
             }
           })
             .hitTestBehavior(HitTestMode.Transparent)
+
+          if (this.isOffsetSubtitleOverlayActive()) {
+            Stack() {
+              SubtitleDisplayBuilder({
+                subtitle: this.player.subtitle,
+                screenWidth: this.player.screenWidth,
+                screenHeight: this.player.screenHeight,
+                showControl: this.showControl,
+                subTitleVisibility: this.subtitleVisibility,
+                subtitle3DMode: this.subtitle3DMode
+              })
+            }
+            .width(this.player.playAreaWidth)
+            .height(this.player.playAreaHeight)
+            .animation({ duration: this.player.playTime > 300 ? 300 : 0, curve: Curve.Ease })
+            .rotate({ y: 2, angle: this.player.angle, perspective: 200 })
+            .translate({ x: this.player.translateX, y: this.player.translateY })
+            .hitTestBehavior(HitTestMode.Transparent)
+            .zIndex(1000)
+          }
 
           AISubtitleComponent({
             isAIAsrShown: this.isAIAsrShown,
@@ -865,7 +988,18 @@ export struct Player { // 播放页
       subtitleVisibility: this.subtitleVisibility,
       isAIAsrShown: this.isAIAsrShown,
       subtitle3DMode: this.subtitle3DMode,
+      onSubtitleOffClick: () => {
+        this.turnOffSubtitleDisplay()
+      },
       onSubtitleOffsetTime: () => {
+        this.activateExternalSubtitle()
+        this.subtitleOffsetShouldResumePlayback = this.player.playing
+        if (this.subtitleOffsetShouldResumePlayback) {
+          this.player.pause()
+        }
+        this.subtitleOffsetPreviewBase = SubtitleUtil.offsetMillis
+        this.isAdjustingSubtitleOffset = true
+        this.refreshExternalSubtitlePreview(this.subtitleOffsetPreviewBase)
         this.subtitleTimestampInputDialog.open()
       },
       onInnerSubtitleClick: () => {
@@ -874,12 +1008,10 @@ export struct Player { // 播放页
         this.player.subtitleSelected = SubtitleMode.INNER_SUBTITLE
       },
       onExternalSubtitleClick: () => {
-        this.isAIAsrShown = false
-        this.subtitleVisibility === Visibility.Visible &&
-          this.player.subtitleSelected === SubtitleMode.EXTERNAL_SUBTITLE ?
-          this.subtitleVisibility = Visibility.None :
-          this.subtitleVisibility = Visibility.Visible
-        this.player.subtitleSelected = SubtitleMode.EXTERNAL_SUBTITLE
+        this.activateExternalSubtitle()
+      },
+      onExternalSubtitleOffClick: () => {
+        this.turnOffSubtitleDisplay()
       },
       onAIAsrClick: () => {
         this.isAIAsrShown = !this.isAIAsrShown

--- a/entry/src/main/ets/pages/VideoPlayer/Player.ets
+++ b/entry/src/main/ets/pages/VideoPlayer/Player.ets
@@ -1165,9 +1165,6 @@ export struct Player { // 播放页
       onExternalSubtitleClick: () => {
         this.activateExternalSubtitle()
       },
-      onExternalSubtitleOffClick: () => {
-        this.turnOffSubtitleDisplay()
-      },
       onAIAsrClick: () => {
         this.isAIAsrShown = !this.isAIAsrShown
         this.subtitleVisibility = Visibility.None

--- a/entry/src/main/ets/pages/VideoPlayer/Player.ets
+++ b/entry/src/main/ets/pages/VideoPlayer/Player.ets
@@ -57,6 +57,7 @@ import { AISubtitleComponent } from '../../component/PlayerComponent/AIAsrCompon
 import PiPWindowUtil from '../../utils/PiPWindowUtil'
 import { DefaultDialogShadow } from '../../common/AttributeModifierConfig'
 import { NumberInputDialog } from '../../component/Dialog/NumberInputDialog'
+import { SubtitleOffsetDialog } from '../../component/Dialog/SubtitleOffsetDialog'
 
 @Component
 export struct Player { // 播放页
@@ -88,15 +89,17 @@ export struct Player { // 播放页
   @Consume('pathStack') pathStack: NavPathStack
   @State exitVideoTime: number = 0
   subtitleTimestampInputDialog: CustomDialogController = new CustomDialogController({
-    builder: NumberInputDialog({
-      title: '外挂字幕偏移时间',
-      placeholderColor: '输入范围：-50000-50000' +
-        (SubtitleUtil.offsetMillis > 0 ? '：' + SubtitleUtil.offsetMillis : ''),
+    builder: SubtitleOffsetDialog({
+      getCurrentValue: () => SubtitleUtil.offsetMillis,
       confirm: (input: number) => {
-        if (input && Math.abs(input || 0) <= 50000) {
-          SubtitleUtil.offsetMillis = input || 0
+        if (Number.isNaN(input)) {
+          ToolsUtil.showToast('未输入偏移')
+          this.subtitleTimestampInputDialog.close()
+        } else if (Math.abs(input) <= 50000) {
+          SubtitleUtil.offsetMillis = input
+          this.subtitleTimestampInputDialog.close()
         } else {
-          ToolsUtil.showToast('输入错误')
+          ToolsUtil.showToast('输入错误：请输入 -50000 到 50000 的整数')
         }
       },
     }), cornerRadius: 20, shadow: DefaultDialogShadow

--- a/entry/src/main/ets/pages/VideoPlayer/Player.ets
+++ b/entry/src/main/ets/pages/VideoPlayer/Player.ets
@@ -274,24 +274,38 @@ export struct Player { // 播放页
   }
 
   private saveSubtitlePreferenceForCurrentVideo(): void {
-    if (!this.player.nowPlaying || !PathUtils.appContext) {
+    const nowPlaying = this.player.nowPlaying
+    const appContext = PathUtils.appContext
+    if (!nowPlaying || !appContext) {
       return
     }
+
     const subtitleMode = this.normalizeSubtitleMode(this.player.subtitleSelected)
     const subtitleVisible = this.subtitleVisibility === Visibility.Visible
     const subtitleAIAsrShown = this.isAIAsrShown
     const subtitle3DMode = this.normalizeSubtitle3DMode(this.subtitle3DMode)
     const subtitleOffsetMillis = Math.max(-50000, Math.min(50000, Math.round(SubtitleUtil.offsetMillis)))
     const subtitleTrackId = this.player.subtitleTrackSelected
+    const hasPreferenceChanged =
+      nowPlaying.subtitle_mode !== subtitleMode ||
+      nowPlaying.subtitle_visible !== subtitleVisible ||
+      nowPlaying.subtitle_ai_asr_shown !== subtitleAIAsrShown ||
+      nowPlaying.subtitle_3d_mode !== subtitle3DMode ||
+      nowPlaying.subtitle_offset_millis !== subtitleOffsetMillis ||
+      nowPlaying.subtitle_track_id !== subtitleTrackId
 
-    this.player.nowPlaying.subtitle_mode = subtitleMode
-    this.player.nowPlaying.subtitle_visible = subtitleVisible
-    this.player.nowPlaying.subtitle_ai_asr_shown = subtitleAIAsrShown
-    this.player.nowPlaying.subtitle_3d_mode = subtitle3DMode
-    this.player.nowPlaying.subtitle_offset_millis = subtitleOffsetMillis
-    this.player.nowPlaying.subtitle_track_id = subtitleTrackId
+    if (!hasPreferenceChanged) {
+      return
+    }
 
-    SelectFileUtil.saveData(PathUtils.appContext!, this.player.nowPlaying, {
+    nowPlaying.subtitle_mode = subtitleMode
+    nowPlaying.subtitle_visible = subtitleVisible
+    nowPlaying.subtitle_ai_asr_shown = subtitleAIAsrShown
+    nowPlaying.subtitle_3d_mode = subtitle3DMode
+    nowPlaying.subtitle_offset_millis = subtitleOffsetMillis
+    nowPlaying.subtitle_track_id = subtitleTrackId
+
+    SelectFileUtil.saveData(appContext, nowPlaying, {
       subtitleMode,
       subtitleVisible,
       subtitleAIAsrShown,

--- a/entry/src/main/ets/pages/VideoPlayer/Player.ets
+++ b/entry/src/main/ets/pages/VideoPlayer/Player.ets
@@ -9,6 +9,7 @@ import VideoOperateUtil from '../../utils/VideoOperateUtil'
 import { VideoMetadata } from '../../interfaces/VideoMetadataInterface'
 import Preferences from '../../database/Preferences'
 import { PathUtils } from '../../utils/PathUtils'
+import SelectFileUtil from '../../utils/SelectFileUtil'
 import { PlayerSideBarComponent } from '../../component/PlayerComponent/PlayerSideBarComponent'
 import { AVCastPickerBuilder } from '../../component/PlayerComponent/AVCastPickerBuilder'
 import { AudioTrackComponent } from '../../component/PlayerComponent/AudioTrackComponent'
@@ -86,12 +87,13 @@ export struct Player { // 播放页
   @State isAIAsrShown: boolean = false
   @State currentSpeedIndex: number = 0
   @State subtitleVisibility: Visibility = Visibility.Visible
-  @State subtitle3DMode: Subtitle3DMode = Subtitle3DMode.DISABLED
+  @State @Watch('onSubtitle3DModeChanged') subtitle3DMode: Subtitle3DMode = Subtitle3DMode.DISABLED
   @Consume('pathStack') pathStack: NavPathStack
   @State exitVideoTime: number = 0
   @State isAdjustingSubtitleOffset: boolean = false
   private subtitleOffsetPreviewBase: number = 0
   private subtitleOffsetShouldResumePlayback: boolean = false
+  private isApplyingSubtitleMetadata: boolean = false
 
   private isOffsetSubtitleOverlayActive(): boolean {
     return this.isAdjustingSubtitleOffset && this.player.subtitleSelected === SubtitleMode.EXTERNAL_SUBTITLE
@@ -158,11 +160,145 @@ export struct Player { // 播放页
     this.subtitleVisibility = Visibility.Visible
     this.player.subtitleSelected = SubtitleMode.EXTERNAL_SUBTITLE
     this.refreshExternalSubtitleByPlaybackTime()
+    this.saveSubtitlePreferenceForCurrentVideo()
   }
 
   private turnOffSubtitleDisplay(): void {
     this.isAIAsrShown = false
     this.subtitleVisibility = Visibility.None
+    this.saveSubtitlePreferenceForCurrentVideo()
+  }
+
+  private onSubtitle3DModeChanged(): void {
+    if (this.isApplyingSubtitleMetadata) {
+      return
+    }
+    this.saveSubtitlePreferenceForCurrentVideo()
+  }
+
+  private normalizeSubtitleMode(subtitleMode?: number): SubtitleMode {
+    if (subtitleMode === SubtitleMode.EXTERNAL_SUBTITLE || subtitleMode === SubtitleMode.AI_SUBTITLE) {
+      return subtitleMode
+    }
+    return SubtitleMode.INNER_SUBTITLE
+  }
+
+  private normalizeSubtitle3DMode(subtitle3DMode?: number): Subtitle3DMode {
+    if (subtitle3DMode === Subtitle3DMode.SIDE_BY_SIDE || subtitle3DMode === Subtitle3DMode.TOP_AND_BOTTOM) {
+      return subtitle3DMode
+    }
+    return Subtitle3DMode.DISABLED
+  }
+
+  private hasSubtitlePreferenceMetadata(nowPlaying: VideoMetadata): boolean {
+    return nowPlaying.subtitle_mode !== undefined ||
+      nowPlaying.subtitle_visible !== undefined ||
+      nowPlaying.subtitle_ai_asr_shown !== undefined ||
+      nowPlaying.subtitle_3d_mode !== undefined ||
+      nowPlaying.subtitle_offset_millis !== undefined ||
+      nowPlaying.subtitle_track_id !== undefined
+  }
+
+  private hasInnerSubtitleTrack(): boolean {
+    return this.player.subtitleTrack.length > 0
+  }
+
+  private hasExternalSubtitle(): boolean {
+    return (this.player.nowPlaying?.external_subtitle_format?.length ?? 0) > 0
+  }
+
+  private applySubtitlePreferenceFromMetadata(): void {
+    const nowPlaying = this.player.nowPlaying
+    if (!nowPlaying) {
+      return
+    }
+    this.isApplyingSubtitleMetadata = true
+
+    if (!this.hasSubtitlePreferenceMetadata(nowPlaying)) {
+      this.isAIAsrShown = false
+      this.subtitle3DMode = Subtitle3DMode.DISABLED
+      SubtitleUtil.offsetMillis = 0
+
+      if (this.hasInnerSubtitleTrack()) {
+        this.subtitleVisibility = Visibility.Visible
+        this.player.subtitleSelected = SubtitleMode.INNER_SUBTITLE
+      } else if (this.hasExternalSubtitle()) {
+        this.subtitleVisibility = Visibility.Visible
+        this.player.subtitleSelected = SubtitleMode.EXTERNAL_SUBTITLE
+        this.refreshExternalSubtitleByPlaybackTime()
+      } else {
+        this.subtitleVisibility = Visibility.None
+        this.player.subtitleSelected = SubtitleMode.INNER_SUBTITLE
+      }
+      this.isApplyingSubtitleMetadata = false
+      this.saveSubtitlePreferenceForCurrentVideo()
+      return
+    }
+
+    const subtitleMode = this.normalizeSubtitleMode(nowPlaying.subtitle_mode)
+    const subtitleVisible = nowPlaying.subtitle_visible ?? true
+    const subtitleAIAsrShown = nowPlaying.subtitle_ai_asr_shown ?? false
+    const subtitle3DMode = this.normalizeSubtitle3DMode(nowPlaying.subtitle_3d_mode)
+    const subtitleTrackId = nowPlaying.subtitle_track_id ?? -1
+    let subtitleOffsetMillis = nowPlaying.subtitle_offset_millis ?? 0
+    subtitleOffsetMillis = Math.max(-50000, Math.min(50000, Math.round(subtitleOffsetMillis)))
+
+    this.subtitle3DMode = subtitle3DMode
+    SubtitleUtil.offsetMillis = subtitleOffsetMillis
+
+    if (subtitleAIAsrShown && canIUse('SystemCapability.AI.AICaption')) {
+      this.isAIAsrShown = true
+      this.subtitleVisibility = Visibility.None
+      this.player.subtitleSelected = SubtitleMode.AI_SUBTITLE
+      this.isApplyingSubtitleMetadata = false
+      this.saveSubtitlePreferenceForCurrentVideo()
+      return
+    }
+
+    this.isAIAsrShown = false
+    this.subtitleVisibility = subtitleVisible ? Visibility.Visible : Visibility.None
+    if (subtitleMode === SubtitleMode.EXTERNAL_SUBTITLE && this.hasExternalSubtitle()) {
+      this.player.subtitleSelected = SubtitleMode.EXTERNAL_SUBTITLE
+      this.refreshExternalSubtitleByPlaybackTime()
+    } else {
+      this.player.subtitleSelected = SubtitleMode.INNER_SUBTITLE
+      if (subtitleTrackId >= 0) {
+        const selectedTrack = this.player.subtitleTrack.find((track) => track.id === subtitleTrackId)
+        if (selectedTrack) {
+          this.player.selectSubtitleTrack(selectedTrack.id)
+        }
+      }
+    }
+    this.isApplyingSubtitleMetadata = false
+    this.saveSubtitlePreferenceForCurrentVideo()
+  }
+
+  private saveSubtitlePreferenceForCurrentVideo(): void {
+    if (!this.player.nowPlaying || !PathUtils.appContext) {
+      return
+    }
+    const subtitleMode = this.normalizeSubtitleMode(this.player.subtitleSelected)
+    const subtitleVisible = this.subtitleVisibility === Visibility.Visible
+    const subtitleAIAsrShown = this.isAIAsrShown
+    const subtitle3DMode = this.normalizeSubtitle3DMode(this.subtitle3DMode)
+    const subtitleOffsetMillis = Math.max(-50000, Math.min(50000, Math.round(SubtitleUtil.offsetMillis)))
+    const subtitleTrackId = this.player.subtitleTrackSelected
+
+    this.player.nowPlaying.subtitle_mode = subtitleMode
+    this.player.nowPlaying.subtitle_visible = subtitleVisible
+    this.player.nowPlaying.subtitle_ai_asr_shown = subtitleAIAsrShown
+    this.player.nowPlaying.subtitle_3d_mode = subtitle3DMode
+    this.player.nowPlaying.subtitle_offset_millis = subtitleOffsetMillis
+    this.player.nowPlaying.subtitle_track_id = subtitleTrackId
+
+    SelectFileUtil.saveData(PathUtils.appContext!, this.player.nowPlaying, {
+      subtitleMode,
+      subtitleVisible,
+      subtitleAIAsrShown,
+      subtitle3DMode,
+      subtitleOffsetMillis,
+      subtitleTrackId
+    })
   }
 
   subtitleTimestampInputDialog: CustomDialogController = new CustomDialogController({
@@ -190,6 +326,7 @@ export struct Player { // 播放页
           SubtitleUtil.offsetMillis = input
           this.refreshExternalSubtitlePreview(input)
           this.finishSubtitleOffsetSession()
+          this.saveSubtitlePreferenceForCurrentVideo()
           this.subtitleTimestampInputDialog.close()
         } else {
           ToolsUtil.showToast('输入错误：请输入 -50000 到 50000 的整数')
@@ -228,6 +365,7 @@ export struct Player { // 播放页
     Preferences.saveVideoSpeed(PathUtils.appContext!,
       (VideoInfoUtil.videoSpeedListAll.includes(this.player.speed) ? this.player.speed : 1) + 'x')
     Preferences.saveRepeatModeState(PathUtils.appContext!, this.player.repeatMode)
+    this.saveSubtitlePreferenceForCurrentVideo()
     WindowUtil.setBarState(PathUtils.appContext!, true, true)
     clearTimeout(this.exitVideoTime)
     this.player.cancelSubscribe()
@@ -325,6 +463,7 @@ export struct Player { // 播放页
           ToolsUtil.addLogger("开始播放视频", false, this.pathStack)
           await this.player.getAudioTrackList()
           await this.player.getSubtitleTrackList()
+          this.applySubtitlePreferenceFromMetadata()
           ToolsUtil.addLogger("获取音频轨道完成", false, this.pathStack)
           await this.player.initVolumeAndBrightness()
           this.player.updatePlaybackSpeed(this.player.speed)
@@ -727,6 +866,7 @@ export struct Player { // 播放页
     })
     .onWillDisappear(async () => {
       ToolsUtil.addLogger("开始执行onWillDisappear生命周期", false, this.pathStack)
+      this.saveSubtitlePreferenceForCurrentVideo()
       VideoOperateUtil.saveLastPlayVideoIndex(this.player.videoMetaDataList, this.player.nowPlaying?.date)
       if (this.player.videoMetaDataList.length > 0 && this.player.playTime > 0) {
         VideoOperateUtil.saveVideoTime(this.player.playTime, this.player.nowPlaying!, this.player.videoMetaDataList,
@@ -1006,6 +1146,7 @@ export struct Player { // 播放页
         this.subtitleVisibility = Visibility.Visible
         this.isAIAsrShown = false
         this.player.subtitleSelected = SubtitleMode.INNER_SUBTITLE
+        this.saveSubtitlePreferenceForCurrentVideo()
       },
       onExternalSubtitleClick: () => {
         this.activateExternalSubtitle()
@@ -1017,6 +1158,7 @@ export struct Player { // 播放页
         this.isAIAsrShown = !this.isAIAsrShown
         this.subtitleVisibility = Visibility.None
         this.player.subtitleSelected = SubtitleMode.AI_SUBTITLE
+        this.saveSubtitlePreferenceForCurrentVideo()
       },
     })
   }

--- a/entry/src/main/ets/utils/SelectFileUtil.ets
+++ b/entry/src/main/ets/utils/SelectFileUtil.ets
@@ -286,6 +286,24 @@ export default class SelectFileUtil {
       if (options.pointB) {
         video.pointB = options.pointB
       }
+      if (options.subtitleMode !== undefined) {
+        video.subtitle_mode = options.subtitleMode
+      }
+      if (options.subtitleVisible !== undefined) {
+        video.subtitle_visible = options.subtitleVisible
+      }
+      if (options.subtitleAIAsrShown !== undefined) {
+        video.subtitle_ai_asr_shown = options.subtitleAIAsrShown
+      }
+      if (options.subtitle3DMode !== undefined) {
+        video.subtitle_3d_mode = options.subtitle3DMode
+      }
+      if (options.subtitleOffsetMillis !== undefined) {
+        video.subtitle_offset_millis = options.subtitleOffsetMillis
+      }
+      if (options.subtitleTrackId !== undefined) {
+        video.subtitle_track_id = options.subtitleTrackId
+      }
     }
     if (PrivacySpaceUtil.getPrivacyMode()) {
       ToolsUtil.addLogger('当前处于隐私空间，更新隐私空间数据', false, undefined, TAG)

--- a/entry/src/main/ets/utils/SubtitleUtil.ets
+++ b/entry/src/main/ets/utils/SubtitleUtil.ets
@@ -250,9 +250,8 @@ class SubtitleUtil {
       return "";
     }
     // 应用偏移量：将播放器时间转换为字幕时间
-    // 约定：offset > 0 时，字幕会延迟显示（视频第 N 毫秒的时候显示第 N + offset 的时候的字幕）
     const effectiveOffset = offsetOverride ?? this.offsetMillis
-    const adjustedTimestamp = timestamp + effectiveOffset;
+    const adjustedTimestamp = timestamp - effectiveOffset;
     // 如果偏移后的时间可能为负数，可以酌情处理
     // 这里简单的将负数视为0，避免越界错误
     const searchTimestamp = Math.max(adjustedTimestamp, 0);
@@ -312,7 +311,7 @@ class SubtitleUtil {
     if (this.subtitles.length === 0) {
       return undefined
     }
-    const searchTimestamp = Math.max(playbackTimestamp + currentOffsetMillis, 0)
+    const searchTimestamp = Math.max(playbackTimestamp - currentOffsetMillis, 0)
     const nextIndex = this.findFirstStartGreaterThan(searchTimestamp)
     const activeIndex = (nextIndex > 0 && this.subtitles[nextIndex - 1].endTimestampMillis >= searchTimestamp)
       ? nextIndex - 1
@@ -328,7 +327,7 @@ class SubtitleUtil {
     if (targetIndex < 0 || targetIndex >= this.subtitles.length) {
       return undefined
     }
-    return this.subtitles[targetIndex].startTimestampMillis - playbackTimestamp
+    return playbackTimestamp - this.subtitles[targetIndex].startTimestampMillis
   }
 
   // 统一解析字幕文件

--- a/entry/src/main/ets/utils/SubtitleUtil.ets
+++ b/entry/src/main/ets/utils/SubtitleUtil.ets
@@ -250,7 +250,8 @@ class SubtitleUtil {
       return "";
     }
     // 应用偏移量：将播放器时间转换为字幕时间
-    const adjustedTimestamp = timestamp - this.offsetMillis;
+    // 约定：offset > 0 时，字幕会延迟显示（视频第 N 毫秒的时候显示第 N + offset 的时候的字幕）
+    const adjustedTimestamp = timestamp + this.offsetMillis;
     // 如果偏移后的时间可能为负数，可以酌情处理
     // 这里简单的将负数视为0，避免越界错误
     const searchTimestamp = Math.max(adjustedTimestamp, 0);

--- a/entry/src/main/ets/utils/SubtitleUtil.ets
+++ b/entry/src/main/ets/utils/SubtitleUtil.ets
@@ -118,7 +118,7 @@ class SubtitleUtil {
       item!.external_subtitle_format = ''
     } else {
       const subtitleName = await this.selectExternalSubtitles(PathUtils.subtitlePath, item?.date!)
-      const subtitleNameFormat = subtitleName?.match(/[^.]+$/)?.[0] || ''
+      const subtitleNameFormat = subtitleName?.match(/[^.]+$/)?.[0]?.toLowerCase() || ''
       switch (subtitleNameFormat) {
         case SubtitleFormat.SRT:
           item!.external_subtitle_format = SubtitleFormat.SRT
@@ -245,13 +245,14 @@ class SubtitleUtil {
     }
   }
 
-  getSubtitlesAtTime(timestamp: number): string {
+  getSubtitlesAtTime(timestamp: number, offsetOverride?: number): string {
     if (this.subtitles.length === 0) {
       return "";
     }
     // 应用偏移量：将播放器时间转换为字幕时间
     // 约定：offset > 0 时，字幕会延迟显示（视频第 N 毫秒的时候显示第 N + offset 的时候的字幕）
-    const adjustedTimestamp = timestamp + this.offsetMillis;
+    const effectiveOffset = offsetOverride ?? this.offsetMillis
+    const adjustedTimestamp = timestamp + effectiveOffset;
     // 如果偏移后的时间可能为负数，可以酌情处理
     // 这里简单的将负数视为0，避免越界错误
     const searchTimestamp = Math.max(adjustedTimestamp, 0);
@@ -303,6 +304,33 @@ class SubtitleUtil {
     ).join('\n');
   }
 
+  getAdjacentSubtitleOffset(
+    playbackTimestamp: number,
+    currentOffsetMillis: number,
+    direction: 'prev' | 'next'
+  ): number | undefined {
+    if (this.subtitles.length === 0) {
+      return undefined
+    }
+    const searchTimestamp = Math.max(playbackTimestamp + currentOffsetMillis, 0)
+    const nextIndex = this.findFirstStartGreaterThan(searchTimestamp)
+    const activeIndex = (nextIndex > 0 && this.subtitles[nextIndex - 1].endTimestampMillis >= searchTimestamp)
+      ? nextIndex - 1
+      : -1
+
+    let targetIndex = -1
+    if (direction === 'prev') {
+      targetIndex = activeIndex >= 0 ? activeIndex - 1 : nextIndex - 1
+    } else {
+      targetIndex = activeIndex >= 0 ? activeIndex + 1 : nextIndex
+    }
+
+    if (targetIndex < 0 || targetIndex >= this.subtitles.length) {
+      return undefined
+    }
+    return this.subtitles[targetIndex].startTimestampMillis - playbackTimestamp
+  }
+
   // 统一解析字幕文件
   private async parseSubtitleFile<T>(
     parser: Parser<T>,
@@ -311,6 +339,20 @@ class SubtitleUtil {
     await parser.init()
     const lines = await parser.readLines()
     return lines.map(mapper)
+  }
+
+  private findFirstStartGreaterThan(timestamp: number): number {
+    let left = 0
+    let right = this.subtitles.length
+    while (left < right) {
+      const mid = Math.floor((left + right) / 2)
+      if (this.subtitles[mid].startTimestampMillis > timestamp) {
+        right = mid
+      } else {
+        left = mid + 1
+      }
+    }
+    return left
   }
 
   // 设置字幕数据

--- a/entry/src/main/ets/utils/SubtitleUtil.ets
+++ b/entry/src/main/ets/utils/SubtitleUtil.ets
@@ -264,7 +264,7 @@ class SubtitleUtil {
       const mid = Math.floor((left + right) / 2);
       const sub = this.subtitles[mid];
       if (sub.startTimestampMillis <= searchTimestamp &&
-        sub.endTimestampMillis >= searchTimestamp) {
+        sub.endTimestampMillis > searchTimestamp) {
         startIndex = mid;
         break;
       } else if (sub.startTimestampMillis > searchTimestamp) {
@@ -280,7 +280,7 @@ class SubtitleUtil {
     result.push(this.subtitles[startIndex]);
     // 向左查找
     for (let i = startIndex - 1; i >= 0; i--) {
-      if (this.subtitles[i].endTimestampMillis >= searchTimestamp) {
+      if (this.subtitles[i].endTimestampMillis > searchTimestamp) {
         result.unshift(this.subtitles[i]);
       } else {
         break;
@@ -313,7 +313,7 @@ class SubtitleUtil {
     }
     const searchTimestamp = Math.max(playbackTimestamp - currentOffsetMillis, 0)
     const nextIndex = this.findFirstStartGreaterThan(searchTimestamp)
-    const activeIndex = (nextIndex > 0 && this.subtitles[nextIndex - 1].endTimestampMillis >= searchTimestamp)
+    const activeIndex = (nextIndex > 0 && this.subtitles[nextIndex - 1].endTimestampMillis > searchTimestamp)
       ? nextIndex - 1
       : -1
 


### PR DESCRIPTION
## 更新字幕体验：
- 新增 SubtitleOffsetDialog
- 重构字幕菜单结构：新增“关闭字幕”，外挂字幕改为二级菜单（启用/关闭 + 偏移），并补齐无内嵌/无外挂字幕的状态反馈与提示
- 新增字幕偏好持久化，统一“无偏好”时行为；同时修复外挂字幕导入与元数据同步链路（含扩展名大小写兼容）

## 建议关注

### 是否符合预期：
- [ ] 字幕偏移弹窗当前行为是“打开时自动暂停，关闭时仅在打开前为播放才自动恢复播放”，还是应改为“关闭后一律自动播放”来方便用户验证偏移
- [ ] 字幕偏移入口已移动到“外挂字幕”二级菜单。当前仅外挂字幕支持偏移；若未来扩展到内嵌字幕和 3D 字幕，建议分开维护不同类型的偏移值，避免冲突
- [ ] 无偏好时是按照内嵌字幕优先，如果两种字幕都没有就关闭
- [ ] 识别是否有外部字幕是靠读取元数据里的 `external_subtitle_format` ，之前版本添加外挂字幕的时候不写入元数据，当前版本会显示无外挂字幕

### 问题：
- [ ] 外挂字幕显隐状态依旧有问题，每次重启app第一次打开视频都不显示外挂字幕，需要重开视频或者重开字幕。我不知道应该怎么修
- [ ] 字幕偏移确认后，当前仍存在“确认后原字幕未立即刷新、只会在在下一条字幕时生效”的现象未解决
- [ ] mpv 内嵌字幕仍有问题，在退出重进视频无法正确显示

*我测试用的视频*
[*counter.zip*](https://github.com/user-attachments/files/26452469/counter.zip)
