### PR TITLE
[update] 修复多选操作bug并优化删除确认流程

### DIFF
--- a/entry/src/main/ets/component/Dialog/BatchVideoDeleteDialog.ets
+++ b/entry/src/main/ets/component/Dialog/BatchVideoDeleteDialog.ets
@@ -1,0 +1,176 @@
+import { DeleteType } from '../../common/enum/DeleteType'
+import { VideoSource } from '../../common/enum/VideoSource'
+import { VideoMetadata } from '../../interfaces/VideoMetadataInterface'
+import SelectFileUtil from '../../utils/SelectFileUtil'
+
+@CustomDialog
+export struct BatchVideoDeleteDialog {
+  confirm?: (deleteType: DeleteType) => void
+  controller?: CustomDialogController
+  videoList: VideoMetadata[] = []
+  isPermanentDelete: boolean = false
+  isMoveToRecent: boolean = false
+  msg: ResourceStr = ''
+
+  aboutToAppear(): void {
+    this.msg = $r('app.string.soft_del_confirm')
+  }
+
+  private getPermanentDeleteVisibility(): boolean {
+    for (let i = 0; i < this.videoList.length; i++) {
+      if (!SelectFileUtil.isPathFromSource(this.videoList[i].uri, VideoSource.SWEET_VIDEO_DOWNLOAD_FILE)) {
+        return false
+      }
+    }
+    return true
+  }
+
+  private getMoveToRecentVisibility(): boolean {
+    for (let i = 0; i < this.videoList.length; i++) {
+      if (SelectFileUtil.isPathFromSource(this.videoList[i].uri, VideoSource.PHOTO_SELECT_OPTION)) {
+        return false
+      }
+    }
+    return true
+  }
+
+  private getDeleteCountText(): string {
+    return `确定要删除选中的 ${this.videoList.length} 个视频吗？`
+  }
+
+  build() {
+    Column({ space: 20 }) {
+      Text('删除确认')
+        .fontSize(20)
+        .fontColor($r('app.color.text_color'))
+        .fontWeight(FontWeight.Medium)
+
+      Text(this.getDeleteCountText())
+        .fontSize(15)
+        .fontColor($r('app.color.text_color'))
+        .opacity(0.85)
+        .textAlign(TextAlign.Start)
+        .lineHeight(22)
+
+      Text(this.msg)
+        .fontSize(14)
+        .fontColor($r('app.color.text_color'))
+        .opacity(0.7)
+        .textAlign(TextAlign.Start)
+        .lineHeight(20)
+
+      if (this.getMoveToRecentVisibility()) {
+        Column({ space: 12 }) {
+          if (this.getPermanentDeleteVisibility()) {
+            Row() {
+              Checkbox({ name: 'permanentDelete', group: 'deleteOptionsGroup' })
+                .selectedColor('#FF4D4F')
+                .shape(CheckBoxShape.CIRCLE)
+                .onChange((checked: boolean) => {
+                  if (checked) {
+                    this.isMoveToRecent = false
+                    this.msg = $r('app.string.hard_del_confirm')
+                  } else if (!this.isMoveToRecent) {
+                    this.msg = $r('app.string.soft_del_confirm')
+                  }
+                })
+                .select(this.isPermanentDelete!!)
+                .width(20)
+                .height(20)
+              Column() {
+                Text('彻底删除文件')
+                  .fontSize(15)
+                  .fontColor(this.isPermanentDelete ? '#FF4D4F' : $r('app.color.text_color'))
+                  .fontWeight(FontWeight.Medium)
+                Text('文件将从设备中永久删除，不可恢复')
+                  .fontSize(12)
+                  .fontColor('#FF4D4F')
+                  .opacity(0.8)
+              }
+              .alignItems(HorizontalAlign.Start)
+              .margin({ left: 8 })
+            }
+            .width('100%')
+          }
+
+          Row() {
+            Checkbox({ name: 'moveToRecent', group: 'deleteOptionsGroup' })
+              .selectedColor($r('app.color.main_color'))
+              .shape(CheckBoxShape.CIRCLE)
+              .onChange((checked: boolean) => {
+                if (checked) {
+                  this.isPermanentDelete = false
+                  this.msg = $r('app.string.recent_del_confirm')
+                } else if (!this.isPermanentDelete) {
+                  this.msg = $r('app.string.soft_del_confirm')
+                }
+              })
+              .select(this.isMoveToRecent!!)
+              .width(20)
+              .height(20)
+            Column() {
+              Text('移至最近删除')
+                .fontSize(15)
+                .fontColor($r('app.color.text_color'))
+                .fontWeight(FontWeight.Medium)
+              Text('文件可在30天内从系统最近删除中恢复')
+                .fontSize(12)
+                .fontColor($r('app.color.text_color'))
+                .opacity(0.6)
+            }
+            .alignItems(HorizontalAlign.Start)
+            .margin({ left: 8 })
+          }
+          .width('100%')
+        }
+        .width('100%')
+        .padding({ left: 8, right: 8 })
+      }
+
+      Flex({ justifyContent: FlexAlign.SpaceAround }) {
+        Button({ type: ButtonType.Normal, stateEffect: true }) {
+          Row({ space: 5 }) {
+            SymbolGlyph($r('sys.symbol.xmark')).fontSize(16).fontColor([$r('app.color.text_color')])
+            Text($r('app.string.cancel'))
+              .fontSize(15)
+              .fontColor($r('app.color.text_color'))
+              .fontWeight(FontWeight.Medium)
+          }.alignItems(VerticalAlign.Center).padding({ left: 12, right: 12 })
+        }
+        .clickEffect({ level: ClickEffectLevel.LIGHT, scale: 0.9 })
+        .backgroundColor($r('sys.color.button_background_color_transparent'))
+        .borderRadius(12)
+        .height(36)
+        .onClick(() => this.controller?.close())
+
+        Button({ type: ButtonType.Normal, stateEffect: true }) {
+          Row({ space: 5 }) {
+            SymbolGlyph($r('sys.symbol.trash_fill'))
+              .fontSize(16)
+              .fontColor(this.isPermanentDelete ? ['#FF4D4F'] : [$r('app.color.text_color')])
+            Text($r('app.string.sure'))
+              .fontSize(15)
+              .fontColor(this.isPermanentDelete ? '#FF4D4F' : $r('app.color.text_color'))
+              .fontWeight(FontWeight.Medium)
+          }.alignItems(VerticalAlign.Center).padding({ left: 12, right: 12 })
+        }
+        .clickEffect({ level: ClickEffectLevel.LIGHT, scale: 0.9 })
+        .backgroundColor(this.isPermanentDelete ? 'rgba(255, 77, 79, 0.15)' :
+          $r('sys.color.button_background_color_transparent'))
+        .borderRadius(12)
+        .height(36)
+        .onClick(() => {
+          this.controller?.close()
+          let deleteType = DeleteType.SOFT
+          if (this.isPermanentDelete) {
+            deleteType = DeleteType.HARD
+          } else if (this.isMoveToRecent) {
+            deleteType = DeleteType.RECENT
+          }
+          this.confirm?.(deleteType)
+        })
+      }.margin({ bottom: 5 })
+    }.padding(20)
+    .width('85%')
+  }
+}

--- a/entry/src/main/ets/component/FileFolderComponent/FileFolderView.ets
+++ b/entry/src/main/ets/component/FileFolderComponent/FileFolderView.ets
@@ -11,6 +11,7 @@ import { EditFileFolderNameDialog } from '../../component/Dialog/EditFileFolderN
 import { FileFolderListBuilder } from './FileFolderListComponent'
 import { DeleteType } from '../../common/enum/DeleteType'
 import { DefaultDialogShadow, MenuFancyModifier } from '../../common/AttributeModifierConfig'
+import { InfoConfirmDialog } from '../../component/Dialog/InfoConfirmDialog'
 
 @ComponentV2
 export struct FileFolderView {
@@ -30,6 +31,26 @@ export struct FileFolderView {
   @Local fileFolderList: FileFolder[] = this.fileFolderSource.getAllData()
   @Consumer() videoListController: VideoListController = new VideoListController()
   @Consumer() sideBarController: SideBarController = new SideBarController()
+  @Local folderDeleteConfirmText: ResourceStr = ''
+  delConfirmDialog: CustomDialogController = new CustomDialogController({
+    builder: InfoConfirmDialog({
+      textInfo: this.folderDeleteConfirmText,
+      confirm: async () => {
+        const folderToDelete = DataSyncUtil.editingFolder
+        if (!folderToDelete) {
+          return
+        }
+        const videosToDelete = Array.from(folderToDelete.video_list)
+        const deletePromises = videosToDelete.map(async item => {
+          await this.videoListController.videoDataSource.deleteItem(DeleteType.SOFT, item)
+        })
+        await Promise.all(deletePromises)
+        this.fileFolderSource.deleteData(this.fileFolderList.findIndex(i => i.date === folderToDelete.date))
+        this.fileFolderList = FileFolderUtil.deleteFileFolder(PathUtils.appContext!, folderToDelete)
+        this.videoListController.videoDataSource.refreshData(this.videoListController.folder)
+      }
+    }), cornerRadius: 20, shadow: DefaultDialogShadow
+  })
 
   build() {
     List() {
@@ -66,16 +87,10 @@ export struct FileFolderView {
         symbolStartIcon: new SymbolGlyphModifier($r("sys.symbol.trash_fill")),
         content: $r('app.string.delete')
       })
-        .onClick(async () => {
-          DataSyncUtil.delMultipleList = Array.from(file_folder.video_list)
-          const deletePromises = DataSyncUtil.delMultipleList.map(async item => {
-            await this.videoListController.videoDataSource.deleteItem(DeleteType.SOFT, item)
-          })
-          await Promise.all(deletePromises)
-          this.videoListController.closeMultipleChoose()
-          this.fileFolderSource.deleteData(this.fileFolderList.findIndex(i => i.date === file_folder.date))
-          this.fileFolderList = FileFolderUtil.deleteFileFolder(PathUtils.appContext!, file_folder)
-          this.videoListController.videoDataSource.refreshData(this.videoListController.folder)
+        .onClick(() => {
+          DataSyncUtil.editingFolder = file_folder
+          this.folderDeleteConfirmText = `确定要删除文件夹 "${file_folder.name}" 吗？\n其中包含 ${file_folder.video_list.length} 个视频。`
+          this.delConfirmDialog.open()
         })
       MenuItem({
         symbolStartIcon: new SymbolGlyphModifier($r('sys.symbol.rename')),

--- a/entry/src/main/ets/component/VideoItemComponent/VideoCardItemComponent.ets
+++ b/entry/src/main/ets/component/VideoItemComponent/VideoCardItemComponent.ets
@@ -22,6 +22,7 @@ export default struct VideoCardItem {
     this.choose = this.delMultipleList.some(item => item.date === this.item.date)
   }
 
+  @Monitor('delMultipleList')
   checkChoose() {
     this.choose = this.delMultipleList.some(item => item.date === this.item.date)
   }

--- a/entry/src/main/ets/component/VideoItemComponent/VideoItemComponent.ets
+++ b/entry/src/main/ets/component/VideoItemComponent/VideoItemComponent.ets
@@ -96,7 +96,7 @@ export class VideoListController {
     XAnimation.runWithAnimation(() => {
       this.multipleChooseState = Visibility.None
     })
-    DataSyncUtil.delMultipleList.length = 0
+    DataSyncUtil.delMultipleList = []
   }
 
   public refresh(width: number, listDisplayMode: ListDisplayMode) {
@@ -131,11 +131,6 @@ export struct VideoList {
         try {
           await VideoMetaDataOperator.deleteItem(this.videoListController, this.fileFolderSource, deleteType,
             DataSyncUtil.editingVideo!)
-          if (DataSyncUtil.delMultipleList.length > 0) {
-            await FileFolderUtil.delVideosFileFolder(PathUtils.appContext!, this.videoListController,
-              this.fileFolderSource)
-          }
-          this.videoListController.closeMultipleChoose()
         } catch (e) {
           ToolsUtil.showToast(`删除失败:${e}`)
         } finally {
@@ -436,18 +431,16 @@ export struct VideoList {
         })
       MenuItem({
         symbolStartIcon: new SymbolGlyphModifier($r('sys.symbol.checkmark_square_on_square')),
-        content: $r('app.string.multiple_choice')
+        content: this.videoListController.multipleChooseState === Visibility.Visible ? '取消多选' :
+          $r('app.string.multiple_choice')
       })
         .onClick(() => {
           XAnimation.runWithAnimation(() => {
             this.videoListController.multipleChooseState =
               this.videoListController.multipleChooseState == Visibility.None ? Visibility.Visible : Visibility.None
           })
-          DataSyncUtil.delMultipleList.length = 0
-          // 选择当前项
-          if (item) {
-            this.delMultipleList.push(item)
-          }
+          this._delMultipleList = item ? [item] : []
+          this.onDelMultipleListChange([...this._delMultipleList])
         })
       MenuItem({
         symbolStartIcon: new SymbolGlyphModifier($r('sys.symbol.play_round_triangle')),

--- a/entry/src/main/ets/component/VideoItemComponent/VideoViewComponent.ets
+++ b/entry/src/main/ets/component/VideoItemComponent/VideoViewComponent.ets
@@ -3,6 +3,7 @@ import { VideoMetadata } from '../../interfaces/VideoMetadataInterface'
 import { SideBarController } from '../SideBarComponent/SideBar'
 import {
   ButtonFancyModifier,
+  DefaultDialogShadow,
   MenuFancyModifier,
   SearchShadowModifier,
   SymbolGlyphFancyModifier
@@ -27,6 +28,8 @@ import { SafeHeight, Setting } from '../../utils/ObservedUtil'
 import { SortComponent } from './SortComponent'
 import { DebounceUtil } from '../../utils/DebounceUtil'
 import { salmonLogger } from 'salmonlogger'
+import { BatchVideoDeleteDialog } from '../Dialog/BatchVideoDeleteDialog'
+import { DeleteType } from '../../common/enum/DeleteType'
 
 const TAG = 'VideoViewComponent'
 
@@ -69,6 +72,22 @@ export struct VideoView {
   SyncDelMultipleList() {
     DataSyncUtil.delMultipleList = this.delMultipleList
   }
+  batchDelConfirmDialog: CustomDialogController = new CustomDialogController({
+    builder: BatchVideoDeleteDialog({
+      videoList: this.delMultipleList,
+      confirm: async (deleteType: DeleteType) => {
+        try {
+          if (this.delMultipleList.length > 0) {
+            await FileFolderUtil.delVideosFileFolder(PathUtils.appContext!, this.videoListController,
+              this.fileFolderSource, deleteType)
+          }
+        } finally {
+          VideoUtils.refresh(this.videoListController, this.fileFolderSource, this.videoListController.folder)
+          this.videoListController.closeMultipleChoose()
+        }
+      }
+    }), cornerRadius: 20, shadow: DefaultDialogShadow
+  })
 
   @Event onScrollToFolderDateChange: (v: string) => void = () => {
   }
@@ -286,25 +305,23 @@ export struct VideoView {
         })
       MenuItem({
         symbolStartIcon: new SymbolGlyphModifier($r('sys.symbol.checkmark_square_on_square')),
-        content: $r('app.string.select_all')
+        content: this.delMultipleList.length === this.videoListController.videoMetaDataList.length &&
+          this.videoListController.videoMetaDataList.length > 0 ? '取消全选' : $r('app.string.select_all')
       })
         .onClick(() => {
-          this.delMultipleList = [...this.videoListController.videoMetaDataList]
+          if (this.delMultipleList.length === this.videoListController.videoMetaDataList.length &&
+            this.videoListController.videoMetaDataList.length > 0) {
+            this.delMultipleList = []
+          } else {
+            this.delMultipleList = [...this.videoListController.videoMetaDataList]
+          }
         })
       MenuItem({
         symbolStartIcon: new SymbolGlyphModifier($r('sys.symbol.trash_fill')),
         content: $r('app.string.delete_selected')
       })
-        .onClick(async () => {
-          try {
-            if (this.delMultipleList.length > 0) {
-              await FileFolderUtil.delVideosFileFolder(PathUtils.appContext!, this.videoListController,
-                this.fileFolderSource)
-            }
-          } finally {
-            VideoUtils.refresh(this.videoListController, this.fileFolderSource, this.videoListController.folder)
-            this.videoListController.closeMultipleChoose()
-          }
+        .onClick(() => {
+          this.batchDelConfirmDialog.open()
         })
       MenuItem({
         symbolStartIcon: new SymbolGlyphModifier($r('sys.symbol.arrow_right_folder_circle')),
@@ -354,6 +371,9 @@ export struct VideoView {
     .justifyContent(FlexAlign.Center)
     .clickEffect({ level: ClickEffectLevel.LIGHT, scale: 0.9 })
     .onClick(() => {
+      if (this.videoListController.multipleChooseState === Visibility.Visible) {
+        return
+      }
       if (this.currentFolderIndex !== index) {
         this.currentFolderIndex = index
         this.switchToFolderByIndex(index)

--- a/entry/src/main/ets/utils/FileFolderUtil.ets
+++ b/entry/src/main/ets/utils/FileFolderUtil.ets
@@ -14,6 +14,9 @@ import SubtitleUtil from './SubtitleUtil'
 import { salmonLogger } from 'salmonlogger'
 import PrivacySpaceUtil from './PrivacySpaceUtil'
 import fileIo from '@ohos.file.fs'
+import { fileUri } from '@kit.CoreFileKit'
+import { fileManagerService } from '@kit.FileManagerServiceKit'
+import { DeleteType } from '../common/enum/DeleteType'
 
 const TAG = 'FileFolderUtil'
 
@@ -83,7 +86,7 @@ export default class FileFolderUtil {
   }
 
   static async delVideosFileFolder(context: Context, videoListController: VideoListController,
-    folderDataSource: FileFolderDataSource) {
+    folderDataSource: FileFolderDataSource, deleteType: DeleteType = DeleteType.SOFT) {
     let folders = Preferences.getFileFolder(context) as FileFolder[]
     let folderIndex = folders.findIndex(i => i.date === videoListController.folder.date)
     const folder = folders[folderIndex]
@@ -98,6 +101,26 @@ export default class FileFolderUtil {
       RecentPlayUtil.delData(PathUtils.appContext!, item.uri)
       await SubtitleUtil.deleteSubtitle(PathUtils.subtitlePath, item.date)
       await SelectFileUtil.deleteCover(item.date)
+
+      if (deleteType == DeleteType.HARD) {
+        try {
+          await fileIo.unlink(item.uri)
+          salmonLogger.addLog('BatchDelete', 'remove file succeed: ' + item.uri)
+        } catch (err) {
+          salmonLogger.addLog('BatchDelete',
+            'remove file failed: ' + (err as Error).message, true)
+        }
+      } else if (deleteType == DeleteType.RECENT) {
+        try {
+          if (canIUse('SystemCapability.FileManagement.FileManagerService.Core')) {
+            await fileManagerService.deleteToTrash(fileUri.getUriFromPath(item.uri))
+          }
+        } catch (error) {
+          salmonLogger.addLog('BatchDelete',
+            'move to trash failed: ' + (error as Error).message, true)
+        }
+      }
+
       surviveVideo.delete(item.uri)
     }
     folder.video_list = Array.from(surviveVideo.values())


### PR DESCRIPTION
修复问题：
- 多选模式下选中标记(checkmark)不激活
- 批量删除缺少确认对话框
- 单文件删除在多选模式下连带删除所有选中项
- 多选时文件夹tab导航未禁用
- 多选菜单文字固定为"多选"
- delMultipleList清空方式导致引用不变
- 文件夹删除复用全局delMultipleList状态

优化：
- 批量删除对话框支持选择删除类型（软删/彻底删除/移至最近删除）
- 全选菜单支持反选（toggle）
- 文件夹删除添加确认对话框
- fileIo.unlink使用await替代回调